### PR TITLE
Add option to register third-party SW

### DIFF
--- a/packages/workbox/index.js
+++ b/packages/workbox/index.js
@@ -62,11 +62,12 @@ module.exports = function nuxtWorkbox (options) {
   })
 
   // Register runtime plugin
+  const swURL = `${routerBase}/${options.swURL || swFileName}`
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
     ssr: false,
     options: {
-      swURL: fixUrl(`${routerBase}/${swFileName}`),
+      swURL: fixUrl(swURL),
       swScope: fixUrl(`${routerBase}/`)
     }
   })


### PR DESCRIPTION
Use case: https://documentation.onesignal.com/docs/web-push-sdk-setup-https#section-can-onesignal-integrate-with-another-service-worker-on-my-site-or-a-progressive-web-app-