### PR TITLE
allow overidding of publicPath for manifest module

### DIFF
--- a/packages/manifest/index.js
+++ b/packages/manifest/index.js
@@ -34,6 +34,7 @@ function addManifest (options) {
     name: process.env.npm_package_name,
     short_name: process.env.npm_package_name,
     description: process.env.npm_package_description,
+    publicPath,
     icons: [],
     start_url: routerBase + '?standalone=true',
     display: 'standalone',
@@ -71,7 +72,7 @@ function addManifest (options) {
 
   // Add manifest meta
   if (!find(this.options.head.link, 'rel', 'manifest')) {
-    this.options.head.link.push({ rel: 'manifest', href: fixUrl(`${publicPath}/${manifestFileName}`) })
+    this.options.head.link.push({ rel: 'manifest', href: fixUrl(`${manifest.publicPath}/${manifestFileName}`) })
   } else {
     console.warn('Manifest meta already provided!')
   }


### PR DESCRIPTION
for CDN use it is important that the manifest is serverd frome the same domain, and not from the CDN.
Even though it is actually allowed to server the manifest from a different domain, you will run into other troubles like start_url is cross-origin and so on that this approach is the easiest one to fix it. (see issue #18)

after this PR it's possible to overwrite the publicPath for manifest module (like it is already possible in workbox module). my nuxt.config.js looks therefore like this (I overwrite the publicPath explicity by my _nuxt path without the cdn)
```
modules: [
      ['@nuxtjs/pwa', {workbox: {publicPath: '/_nuxt/'}, manifest: {publicPath: "/_nuxt/"}}],
  ],
```

regards
Simon