### PR TITLE
Only set og:url when it has been defined through ogHost or options

### DIFF
--- a/packages/meta/index.js
+++ b/packages/meta/index.js
@@ -157,7 +157,7 @@ function generateMeta (_options) {
   if (options.ogHost && options.ogUrl === true) {
     options.ogUrl = options.ogHost
   }
-  if (options.ogUrl && !find(this.options.head.meta, 'property', 'og:url') && !find(this.options.head.meta, 'name', 'og:url')) {
+  if (options.ogUrl && options.ogUrl !== true && !find(this.options.head.meta, 'property', 'og:url') && !find(this.options.head.meta, 'name', 'og:url')) {
     this.options.head.meta.push({hid: 'og:url', name: 'og:url', property: 'og:url', content: options.ogUrl})
   }
 


### PR DESCRIPTION
Fixes a (self-introduced :sweat_smile:) bug which emits og:url if `ogUrl` is set to true, but no `ogHost` is defined.
This will also fix the build.