### PR TITLE
Improve the behavior of empty-title replacement

### DIFF
--- a/packages/meta/index.js
+++ b/packages/meta/index.js
@@ -99,7 +99,7 @@ function generateMeta (_options) {
   }
 
   // Title
-  if (options.name && !this.options.head.title) {
+  if (options.name && !this.options.head.title && typeof(this.options.head.titleTemplate) !== 'function') {
     this.options.head.title = options.name
   }
 


### PR DESCRIPTION
We shouldn't replace empty `head.title` with `options.name` when the `head.titleTemplate` is a function.

The `head.titleTemplate` function is used to generate the default title when `head.title` is intentionally set to be null. See [this](https://github.com/declandewet/vue-meta#titletemplate-string--function)