### PR TITLE
feat: add new attribute to link tag for manifest.json

### DIFF
--- a/packages/manifest/index.js
+++ b/packages/manifest/index.js
@@ -72,7 +72,9 @@ function addManifest (options) {
 
   // Add manifest meta
   if (!find(this.options.head.link, 'rel', 'manifest')) {
-    this.options.head.link.push({ rel: 'manifest', href: fixUrl(`${manifest.publicPath}/${manifestFileName}`) })
+    const baseAttribute = { rel: 'manifest', href: fixUrl(`${manifest.publicPath}/${manifestFileName}`) }
+    const attribute = manifest.crossorigin ? Object.assign({}, baseAttribute, { crossorigin: manifest.crossorigin }) : baseAttribute
+    this.options.head.link.push(attribute)
   } else {
     console.warn('Manifest meta already provided!')
   }


### PR DESCRIPTION
In the case of Basic Authentication, manifest.json isn't downloaded properly.
To solve this problem, I added the `crossorigin` attribute for `link` tag.
We can set the attribute as below.

```javascript:nuxt.config.js
modules: [
  ['@nuxtjs/pwa', {manifest: {crossorigin: "use-credentials"}}],
],
```

As a result, `link` tag is generated as below.

```html:index.html
<link data-n-head="true" rel="manifest" href="/_nuxt/manifest.json" crossorigin="use-credentials"/>
```

regards
Hiroki