### PR TITLE
[FIX] routing order for runtime caching (/.*)

### DIFF
--- a/packages/workbox/index.js
+++ b/packages/workbox/index.js
@@ -112,14 +112,6 @@ function getOptions (moduleOptions) {
     delete options.offlinePageAssets
   }
 
-  // Optionally cache other routes for offline
-  if (options.offline && !options.offlinePage) {
-    options._runtimeCaching.push({
-      urlPattern: fixUrl(`${routerBase}/.*`),
-      handler: 'networkFirst'
-    })
-  }
-
   if (options.cachingExtensions) {
     options.cachingExtensions = loadScriptExtension.call(this, options.cachingExtensions)
   }
@@ -136,6 +128,15 @@ function getOptions (moduleOptions) {
 // =============================================
 
 function addTemplates (options) {
+  // Optionally cache other routes for offline
+  const routerBase = this.options.router.base
+  if (options.offline && !options.offlinePage) {
+    options.runtimeCaching.push({
+      urlPattern: fixUrl(`${routerBase}/.*`),
+      handler: 'networkFirst'
+    })
+  }
+
   // Add sw.template.js
   this.addTemplate({
     src: path.resolve(__dirname, 'templates/sw.template.js'),


### PR DESCRIPTION
Related: [#97](https://github.com/nuxt-community/pwa-module/issues/97)

maybe it is caused routing order when register this route (/.*). i try to place it last