### PR TITLE
feat: change the order of default runtimeCache

### DIFF
--- a/packages/workbox/index.js
+++ b/packages/workbox/index.js
@@ -147,7 +147,7 @@ function addTemplates (options) {
       routingExtensions: options.routingExtensions,
       config: options.config,
       importScripts: [options.wbDst].concat(options.importScripts || []),
-      runtimeCaching: [].concat(options._runtimeCaching, options.runtimeCaching).map(i => (Object.assign({}, i, {
+      runtimeCaching: [].concat(options.runtimeCaching, options._runtimeCaching).map(i => (Object.assign({}, i, {
         urlPattern: i.urlPattern,
         handler: i.handler || 'networkFirst',
         method: i.method || 'GET'


### PR DESCRIPTION
## Overview
By default, runtimeCache is added for base URL as below.

```js
workbox.routing.registerRoute(new RegExp('/.*'), workbox.strategies.networkFirst({}), 'GET')
```

Then, I have an problem.
When I add runtimeCache for `/api/xxxxxx` and set the strategy except for `networkFirst`, for example `cacheFirst`, it doesn't work because of the order.
I want to change the default runtimeCache order to avoid this problem.

### example setting
```js
  workbox: {
    skipWaiting: true,
    clientsClaim: true,
    runtimeCaching: [
      {
        urlPattern: '/api/xxxxxx/.*',
        handler: 'cacheFirst',
        method: 'GET',
        strategyOptions: {
          cacheExpiration: {
            maxAgeSeconds: 60 * 15, // 15min
          },
          cacheableResponse: {
            statuses: [200],
          },
        },
      },\
    ],
  },
```

### example output
```js
workbox.routing.registerRoute(new RegExp('/.*'), workbox.strategies.networkFirst({}), 'GET')

workbox.routing.registerRoute(new RegExp('/api/xxxxxx/.*'), workbox.strategies. cacheFirst({"cacheExpiration":{"maxAgeSeconds":900},"cacheableResponse":{"statuses":[200]}}), 'GET')
```
I intend that the request for`/api/xxxxxx/.*` refers to cache firstly.
But it fetches the data from network firstly.

## Solution
`/api/xxxxxx` matches with both url pattern. Then the first pattern is adopted on workbox.
I think the default runtimeCache setting should be set to the last by default.

## Current Work Around
I have an idea to avoid that situation but it is somewhat complex.
- set `false` to `offline`option 
- set default url pattern at the end of `runtimeCache` option

### example setting
```js
  workbox: {
    offline: false,
    skipWaiting: true,
    clientsClaim: true,
    runtimeCaching: [
      {
        urlPattern: '/api/xxxxxx/.*',
        handler: 'cacheFirst',
        method: 'GET',
        strategyOptions: {
          cacheExpiration: {
            maxAgeSeconds: 60 * 15, // 15min
          },
          cacheableResponse: {
            statuses: [200],
          },
        },
      },
      {
         urlPattern: '/*',
         handler: 'networkFirst',
         method: 'GET',
       },
    ],
  },
```

### example output
```js
workbox.routing.registerRoute(new RegExp('/api/xxxxxx/.*'), workbox.strategies. cacheFirst({"cacheExpiration":{"maxAgeSeconds":900},"cacheableResponse":{"statuses":[200]}}), 'GET')

workbox.routing.registerRoute(new RegExp('/.*'), workbox.strategies.networkFirst({}), 'GET')
```
It works.