### PR TITLE
fix: add workboxExtensions to defaults

### DIFF
--- a/packages/workbox/lib/defaults.js
+++ b/packages/workbox/lib/defaults.js
@@ -16,6 +16,7 @@ module.exports = {
 
   cachingExtensions: [],
   routingExtensions: [],
+  workboxExtensions: [],
 
   clientsClaim: true,
   skipWaiting: true,


### PR DESCRIPTION
Hey @pi0, great work on rewriting the workbox module!

I just noticed that `workboxExtensions` is missing in `defaults.js`, that's actually breaking the build as the `readJSFiles` function expects an Array.