### PR TITLE
fix(pwa-utils): handle non-strings in `startCase`

### DIFF
--- a/packages/pwa-utils/index.js
+++ b/packages/pwa-utils/index.js
@@ -31,7 +31,7 @@ function getRouteParams (options) {
 }
 
 function startCase (str) {
-  return str[0].toUpperCase() + str.substr(1)
+  return typeof str === 'string' ? str[0].toUpperCase() + str.substr(1) : str
 }
 
 module.exports = {


### PR DESCRIPTION
adding a route to `workbox.runtimeCaching` results in
```
✖ Nuxt Fatal Error                                 
│                                                      
│   TypeError: Cannot read property '0' of undefined 
```
if its handler is undefined