### PR TITLE
Allow cache names to be configured

### DIFF
--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -48,6 +48,10 @@ It is recommanded to test workbox using `nuxt build`/`nuxt start`. You can enabl
 
 <!-- Config -->
 
+### `cacheNames`
+
+(Object) Configure the workbox cache names.
+
 ### `config`
 
 (Object) Options to be passed to workbox before using it's modules. By default `debug` field will be set to `false` for production builds.

--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -50,7 +50,7 @@ It is recommanded to test workbox using `nuxt build`/`nuxt start`. You can enabl
 
 ### `cacheNames`
 
-(Object) Configure the workbox cache names.
+(Object) Configure the workbox cache names. See [workbox docs](https://developers.google.com/web/tools/workbox/guides/configure-workbox#configure_cache_names) for more information on this.
 
 ### `config`
 

--- a/packages/workbox/templates/sw.js
+++ b/packages/workbox/templates/sw.js
@@ -9,6 +9,11 @@ importScripts(<%= [options.workboxURL, ...options.importScripts].map((i) => `'${
 workbox.setConfig(<%= JSON.stringify(options.config, null, 2) %>)
 <% } %>
 
+<% if (options.cacheNames) {%>
+// Set workbox cache names
+workbox.core.setCacheNameDetails(<%= JSON.stringify(options.cacheNames, null, 2) %>)
+<% } %>
+
 <% if (options.clientsClaim) { %>
 // Start controlling any existing clients as soon as it activates
 workbox.core.clientsClaim()

--- a/test/__snapshots__/pwa.test.js.snap
+++ b/test/__snapshots__/pwa.test.js.snap
@@ -64,6 +64,12 @@ workbox.setConfig({
   \\"debug\\": true
 })
 
+// Set workbox cache names
+workbox.core.setCacheNameDetails({
+  \\"prefix\\": \\"test\\",
+  \\"googleAnalytics\\": \\"test-ga\\"
+})
+
 // Start controlling any existing clients as soon as it activates
 workbox.core.clientsClaim()
 

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     cacheNames: {
       prefix: 'test',
-      googleAnalytics: 'test-analytics'
+      googleAnalytics: 'test-ga'
     },
     importScripts: [
       'custom-sw.js'

--- a/test/fixture/nuxt.config.js
+++ b/test/fixture/nuxt.config.js
@@ -30,6 +30,10 @@ module.exports = {
     config: {
       debug: true
     },
+    cacheNames: {
+      prefix: 'test',
+      googleAnalytics: 'test-analytics'
+    },
     importScripts: [
       'custom-sw.js'
     ],


### PR DESCRIPTION
This is a proposal to add the ability to configure the workbox cache names.

See https://developers.google.com/web/tools/workbox/guides/configure-workbox#configure_cache_names for more information on this.