### PR TITLE
ensure oneSignalSDKWorker.js resolves when using nested routes

### DIFF
--- a/packages/onesignal/index.js
+++ b/packages/onesignal/index.js
@@ -86,7 +86,7 @@ function addOneSignal (moduleOptions) {
   if (!this.options.workbox) {
     this.options.workbox = {}
   }
-  this.options.workbox.swURL = 'OneSignalSDKWorker.js'
+  this.options.workbox.swURL = '/OneSignalSDKWorker.js'
 
   // Provide OneSignalSDKWorker.js and OneSignalSDKUpdaterWorker.js
   const makeSW = (name, scripts) => {


### PR DESCRIPTION
It appears that `oneSignalSDKWorker.js` does not properly resolve when using nested routes.

I attempted to write a test for this but couldn't figure out a good way to test it -- If we think it's valuable I'd be more than happy to write one/some if someone can provide me with some guidance.

Here's an example of the problem:
![image](https://user-images.githubusercontent.com/1071954/53681913-4cfa6d80-3cad-11e9-8a80-d552e59702b4.png)

It's also actively occurring on my website if it helps to see it live: https://pushoflove.com/feed/63b77785-806b-41b9-9e7a-c8813d79a1bf
