### PR TITLE
fix(icon): handle situation where the iconSrc is `null` or `undefined`

### DIFF
--- a/packages/icon/index.js
+++ b/packages/icon/index.js
@@ -68,7 +68,7 @@ async function findIcon (options) {
     options.iconSrc,
     path.resolve(this.options.srcDir, this.options.dir.static, options.iconFileName),
     path.resolve(this.options.srcDir, this.options.dir.assets, options.iconFileName)
-  ]
+  ].filter(p => p)
 
   for (const iconSrc of iconSearchPath) {
     if (await fs.exists(iconSrc)) {


### PR DESCRIPTION

Handle situation where iconSrc could be `null`, `undefined` or falsey.
