### PR TITLE
feat(manifest): add option to disable manifest file hash

### DIFF
--- a/packages/manifest/index.js
+++ b/packages/manifest/index.js
@@ -19,10 +19,13 @@ function addManifest (_options) {
 
   // Combine sources
   const defaults = {
+    // Module options (not part of the manifest)
+    publicPath,
+    fileHash: true,
+    // Manifest defaults
     name: process.env.npm_package_name,
     short_name: process.env.npm_package_name,
     description: process.env.npm_package_description,
-    publicPath,
     icons: [],
     start_url: routerBase + '?standalone=true',
     display: 'standalone',
@@ -36,10 +39,11 @@ function addManifest (_options) {
   const manifest = { ...options }
   delete manifest.src
   delete manifest.publicPath
+  delete manifest.fileHash
 
   // Stringify manifest & generate hash
   const manifestSource = JSON.stringify(manifest)
-  const manifestFileName = `manifest.${hash(manifestSource)}.json`
+  const manifestFileName = options.fileHash ? `manifest.${hash(manifestSource)}.json` : 'manifest.json'
 
   // Merge final manifest into options.manifest for other modules
   if (!this.options.manifest) {


### PR DESCRIPTION
As per the [WebAPKs guide](https://developers.google.com/web/fundamentals/integration/webapks) on Google Developers website, it's recommended to not change the manifest file name:

> Chrome will only update a WebAPK if the Web Manifest URL does not change. If you change the web page from referencing `<link rel="manifest.json">` to reference `<link rel="manifest2.json">` the WebAPK will no longer update. (Don't do this!)

So I have added an option to disable the manifest file hash while keeping the default to `true`.