### PR TITLE
docs: tip for `pwa.manifest.display: 'browser'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.0.0-beta.18](https://github.com/nuxt-community/pwa-module/compare/v3.0.0-beta.17...v3.0.0-beta.18) (2019-09-09)
+
+
+### Bug Fixes
+
+* revert compileTemplate as is fixed by nuxt/nuxt.js[#6283](https://github.com/nuxt-community/pwa-module/issues/6283) for 2.9.x ([d0f96de](https://github.com/nuxt-community/pwa-module/commit/d0f96de))
+* use shared pwa context ([3c19bae](https://github.com/nuxt-community/pwa-module/commit/3c19bae))
+
 ## [3.0.0-beta.17](https://github.com/nuxt-community/pwa-module/compare/v3.0.0-beta.16...v3.0.0-beta.17) (2019-09-05)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.0.0-beta.19](https://github.com/nuxt-community/pwa-module/compare/v3.0.0-beta.18...v3.0.0-beta.19) (2019-09-11)
+
+
+### Bug Fixes
+
+* expose modified pwa context to the config ([c325e44](https://github.com/nuxt-community/pwa-module/commit/c325e44))
+* truncate manifest hash ([5c74621](https://github.com/nuxt-community/pwa-module/commit/5c74621))
+
 ## [3.0.0-beta.18](https://github.com/nuxt-community/pwa-module/compare/v3.0.0-beta.17...v3.0.0-beta.18) (2019-09-09)
 
 

--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -280,8 +280,10 @@ Add it to the `plugins` section of `nuxt.config.js`:
 ```js
 {
   plugins: [
-    src: '~/plugins/sw.js',
-    ssr: false
+    {
+      src: '~/plugins/sw.js',
+      ssr: false
+    }
   ]
 }
 ```

--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -332,3 +332,19 @@ workbox.routing.registerRoute(
 ```
 
 Thanks to [@CarterLi](https://github.com/CarterLi) for the tip.
+
+### Disable Add to Home Screen button (the mini-infobar)
+
+A PWA can be installed by the user if it meets a set of **criteria** and as installable it can trigger an "Add to Home Screen" button (the mini-infobar) as described [here](https://developers.google.com/web/fundamentals/app-install-banners/).
+
+One **criteria** is that `display` must be either `fullscreen`, `standalone`, or `minimal-ui`. If you want to _prevent_ the mini-infobar from appearing in your App, you can set the `pwa.manifest.display` to `browser` in `nuxt.config.js`:
+
+```js
+{
+  pwa {
+   manifest: {
+      display: 'browser'
+    }
+  }
+}
+```

--- a/lib/manifest/module.js
+++ b/lib/manifest/module.js
@@ -40,7 +40,7 @@ function addManifest (pwa) {
 
   // Stringify manifest & generate hash
   const manifestSource = JSON.stringify(manifest)
-  const manifestFileName = `manifest.${hash(manifestSource)}.json`
+  const manifestFileName = `manifest.${hash(manifestSource).substr(0, 8)}.json`
 
   // Merge final manifest into options.manifest for other modules
   if (!this.options.manifest) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,7 +2,8 @@ module.exports = async function nuxtPWA (moduleOptions) {
   const modules = ['icon', 'manifest', 'meta', 'workbox']
 
   // Shared options context
-  const pwa = { ...this.options.pwa, ...moduleOptions }
+  this.options.pwa = { ...(this.options.pwa || {}), ...(moduleOptions || {}) }
+  const { pwa } = this.options.pwa
 
   // Normalize options
   for (const name of modules) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,7 @@ module.exports = async function nuxtPWA (moduleOptions) {
 
   // Shared options context
   this.options.pwa = { ...(this.options.pwa || {}), ...(moduleOptions || {}) }
-  const { pwa } = this.options.pwa
+  const { pwa } = this.options
 
   // Normalize options
   for (const name of modules) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/pwa",
-  "version": "3.0.0-beta.17",
+  "version": "3.0.0-beta.18",
   "description": "Supercharge Nuxt with a heavily tested, updated, zero-config and stable PWA solution!",
   "repository": "nuxt-community/pwa-module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/pwa",
-  "version": "3.0.0-beta.18",
+  "version": "3.0.0-beta.19",
   "description": "Supercharge Nuxt with a heavily tested, updated, zero-config and stable PWA solution!",
   "repository": "nuxt-community/pwa-module",
   "files": [


### PR DESCRIPTION
As mentioned in #247 , this PR adds a tip in the examples section on how to use `nuxt.config` options to prevent the automatic PWA mini-infobar (Add to Home Screen Banner) on mobil devices.