### PR TITLE
docs: use CacheFirst instead of  cacheFirst

### DIFF
--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -312,7 +312,7 @@ Safari requires rangeRequests.
 ```js
 workbox.routing.registerRoute(
   /\.(mp4|webm)/,
-  workbox.strategies.cacheFirst({
+  new workbox.strategies.CacheFirst({
     plugins: [
       new workbox.rangeRequests.Plugin(),
     ],


### PR DESCRIPTION
The 'workbox.strategies.cacheFirst()' function has been deprecated and will be removed in a future version of Workbox.
Please use 'new workbox.strategies.CacheFirst()' instead.