### PR TITLE
docs: fix typo in `icon.md`

### DIFF
--- a/docs/modules/icon.md
+++ b/docs/modules/icon.md
@@ -14,7 +14,7 @@ You can pass options to `pwa.icon` in `nuxt.config.js` to override defaults.
 
 ```js
 pwa: {
-  icons: {
+  icon: {
     /* icon options */
   }
 }


### PR DESCRIPTION
I hope that typo fix will save some debugging time 😅 