### PR TITLE
docs: added new option to change to name of the sw

### DIFF
--- a/docs/modules/workbox.md
+++ b/docs/modules/workbox.md
@@ -167,6 +167,10 @@ Default: `/`
 
 (String) If you need to register another service worker (OneSignal, etc) you can use this option.
 
+### `swDest`
+
+(String) If you want to change the name of service worker, you must use this option with swURL.
+
 ### `swScope`
 
 (String) Defaults to `routerBase`.

--- a/lib/workbox/defaults.js
+++ b/lib/workbox/defaults.js
@@ -40,6 +40,7 @@ module.exports = {
   swTemplate: undefined,
   swUrl: undefined,
   swScope: undefined,
+  swDest: undefined,
 
   // Router
   routerBase: undefined,


### PR DESCRIPTION
The project I am working on has two code bases in the same domain (hurriyetemlak.com mobile & desktop). Sometimes there may be a conflict due to the operation of sw in some cases. It fixed when I changed sw's name. I saw how to change it isn't in the document.