### PR TITLE
docs: add algolia search

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,10 @@ module.exports = {
   title: '⚡ Nuxt PWA',
   description: 'Supercharge Nuxt with a heavily tested, updated and stable PWA solution',
   themeConfig: {
+    algolia: {
+      apiKey: '0226f37644ef2eaccb45814b7b906ec2',
+      indexName: 'nuxtjs_pwa'
+    },
     repo: 'nuxt-community/pwa-module',
     editLinks: true,
     docsDir: 'docs',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.