### PR TITLE
docs(setup): change 'modules' to 'buildModules'

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,18 +7,20 @@
 1. Install npm package:
 
 ```js
-yarn add @nuxtjs/pwa //or npm i @nuxtjs/pwa
+yarn add --dev @nuxtjs/pwa //or npm i --save-dev @nuxtjs/pwa
 ```
 
 2. Edit your `nuxt.config.js` file to add pwa module:
 
 ```js
 {
-    modules: [
+    buildModules: [
         '@nuxtjs/pwa',
     ],
 }
 ```
+
+ℹ️ If you are using `nuxt < 2.9.0` or `SPA` mode with `nuxt start`, use `modules` property instead.
 
 3. Ensure `static` dir exists and optionally create `static/icon.png`. (Recommended to be square png and >= `512x512px`)
 
@@ -31,7 +33,7 @@ sw.*
 PWA module is a collection of smaller modules that are designed to magically work out of the box together. To disable each sub-module, you can pass `false` option with its name as key. For example to disable _icon_ module:
 
 ```js
-modules: [
+buildModules: [
     ['@nuxtjs/pwa', { icon: false }],
 ],
 ```


### PR DESCRIPTION
I am using the version `2.12.2` of nuxt and the module does not generate the files when registered in the `modules` section of `nuxt.config.js`. So I guess now it is required to be in the `buildModules`. 

I also changed it to a dev dependency as the [buildModules documentation](https://nuxtjs.org/guide/modules#build-only-modules) suggests.