### PR TITLE
fix(module): icon purpose warning appearing when it shouldn't

### DIFF
--- a/lib/icon/module.js
+++ b/lib/icon/module.js
@@ -52,7 +52,7 @@ async function run (pwa, _emitAssets) {
     const len = purpose.length
     const validPurpose = ['badge', 'maskable', 'any']
     options.purpose = purpose.filter(item => validPurpose.includes(item))
-    if (len !== options.purpose.len) {
+    if (len !== options.purpose.length) {
       // eslint-disable-next-line no-console
       console.warn('[pwa] [icon] Some invalid items removed from `options.purpose`. Valid values: ' + validPurpose)
     }


### PR DESCRIPTION
.len is undefined, should be .length.