### PR TITLE
fix(icon): update warning url to docs

### DIFF
--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -109,7 +109,7 @@ function generateMeta (pwa) {
 
   const favicon = join(this.options.srcDir, this.options.dir.static, 'favicon.ico')
   if (options.favicon && !find(this.options.head.link, 'rel', 'shortcut icon') && existsSync(favicon)) {
-    console.warn('You are using a low quality icon, use icon png. See https://pwa.nuxtjs.org/modules/icon.html')
+    console.warn('You are using a low quality icon, use icon png. See https://pwa.nuxtjs.org/icon/')
 
     this.options.head.link.push({ rel: 'shortcut icon', href: 'favicon.ico' })
   }


### PR DESCRIPTION
I stumbled upon this console warning today but the URL was wrong and it pointed to a 404 page of the doc. This should be the right URL to use.