### PR TITLE
fix(workbox): missing required parameter request for handle()

### DIFF
--- a/lib/workbox/templates/sw.js
+++ b/lib/workbox/templates/sw.js
@@ -62,8 +62,8 @@ workbox.precaching.precacheAndRoute(<%= JSON.stringify(options.preCaching, null,
 
 <% if (options.offlinePage) { %>
 // Register router handler for offlinePage
-workbox.routing.registerRoute(new RegExp('<%= options.pagesURLPattern %>'), ({event}) => {
-  return new workbox.strategies.<%= options.offlineStrategy %>().handle({event})
+workbox.routing.registerRoute(new RegExp('<%= options.pagesURLPattern %>'), ({request,event}) => {
+  return new workbox.strategies.<%= options.offlineStrategy %>().handle({request,event})
     .catch(() => caches.match('<%= options.offlinePage %>'))
 })<% } %>
 


### PR DESCRIPTION
According to [the Workbox Migration Guide](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v4#removal_of_makerequest_from_workbox-strategies):
> In v5, `handle()` treats `request` as a required parameter, and will not fall back to using `event.request`. Make sure that you pass in a valid request when calling `handle()`.<sup>1</sup>

However, our [`sw.js` template](https://github.com/nuxt-community/pwa-module/blob/1e1ae7bf11bd4e36c566d9514308c83409691a10/lib/workbox/templates/sw.js#L66) only passes `event` parameter. 

This causes websites with `offlinePage` setup always redirects to the offline page.

This pull request fixes it.

<sub><sup>1. However, [the reference docs](https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-strategies.StaleWhileRevalidate#handle) seems have not been updated.</sup></sub>


