### PR TITLE
fix(icon): fork without original process args

### DIFF
--- a/lib/icon/module.js
+++ b/lib/icon/module.js
@@ -219,7 +219,7 @@ async function resizeIcons (options) {
   await fs.mkdirp(options.cacheDir)
 
   await new Promise((resolve, reject) => {
-    const child = fork(require.resolve('./resize'), [resizeOpts])
+    const child = fork(require.resolve('./resize'), [resizeOpts], { execArgv: [] })
     child.on('exit', (code) => {
       return code ? reject(code) : resolve()
     })


### PR DESCRIPTION
When we start the server e.g. with --inspect and forking it
with the default process.execArgv it will cause an error,
because it wants to start the inspector again on the same port.

This patch fixes this issue.

Related to https://github.com/nuxt-community/pwa-module/issues/218