### PR TITLE
fix(manifest): do not use nuxt loading bar color as default `theme_color`

### DIFF
--- a/docs/content/en/manifest.md
+++ b/docs/content/en/manifest.md
@@ -32,7 +32,7 @@ pwa: {
 | `start_url` <sup>\*1</sup>        | `String`        | `routerBase + '?standalone=true'`                            | It has to be relative to where the manifest is placed           |
 | `display` <sup>\*1</sup>          | `String`        | `'standalone'`                                               |                                                                 |
 | `background_color` <sup>\*2</sup> | `String`        | `'#ffffff'`                                                  |                                                                 |
-| `theme_color` <sup>\*2</sup>      | `String`        | `this.options.loading.color`                                 | Nuxt [loading color] option                                     |
+| `theme_color` <sup>\*2</sup>      | `String`        | `this.options.pwa.meta.theme_color`                          | This module's meta theme-color (see the [meta module])          |
 | `dir`                             | `String`        | `'ltr'`                                                      | `ltr` or `rtl`. Used with `lang`                                |
 | `lang`                            | `String`        | `'en'`                                                       | Recommended if used `dir`                                       |
 | `useWebmanifestExtension` <sup>\*3</sup>       | `Boolean`       | `false`                                                      | Whether to use `webmanifest` file extension (or default `json`) |
@@ -43,7 +43,8 @@ pwa: {
 - <sup>\*2</sup> Recommended (according [to Google](https://web.dev/add-manifest))
 - <sup>\*3</sup> Please see [wiki](https://github.com/nuxt-community/pwa-module/wiki/.webmanifest)
 
-[icon module]: https://pwa.nuxtjs.org/modules/icon.html
+[icon module]: https://pwa.nuxtjs.org/icon
+[meta module]: https://pwa.nuxtjs.org/meta
 [maximum of 45 characters]: https://developer.chrome.com/apps/manifest/name
 [maximum of 12 characters]: https://developer.chrome.com/apps/manifest/name
 [loading color]: https://nuxtjs.org/api/configuration-loading/#customizing-the-progress-bar

--- a/docs/content/en/manifest.md
+++ b/docs/content/en/manifest.md
@@ -32,7 +32,7 @@ pwa: {
 | `start_url` <sup>\*1</sup>        | `String`        | `routerBase + '?standalone=true'`                            | It has to be relative to where the manifest is placed           |
 | `display` <sup>\*1</sup>          | `String`        | `'standalone'`                                               |                                                                 |
 | `background_color` <sup>\*2</sup> | `String`        | `'#ffffff'`                                                  |                                                                 |
-| `theme_color` <sup>\*2</sup>      | `String`        | `this.options.pwa.meta.theme_color`                          | This module's meta theme-color (see the [meta module])          |
+| `theme_color` <sup>\*2</sup>      | `String`        | `pwa.meta.theme_color`                                       | This module's meta theme-color (see the [meta module])          |
 | `dir`                             | `String`        | `'ltr'`                                                      | `ltr` or `rtl`. Used with `lang`                                |
 | `lang`                            | `String`        | `'en'`                                                       | Recommended if used `dir`                                       |
 | `useWebmanifestExtension` <sup>\*3</sup>       | `Boolean`       | `false`                                                      | Whether to use `webmanifest` file extension (or default `json`) |

--- a/docs/content/en/meta.md
+++ b/docs/content/en/meta.md
@@ -63,7 +63,7 @@ Please read this resources before you enable `mobileAppIOS` option:
 - Meta: `description`
 
 ### `theme_color`
-- Default: options.loading.color
+- Default: `undefined`
 - Meta: `theme-color`
 
 ### `lang`

--- a/lib/manifest/module.js
+++ b/lib/manifest/module.js
@@ -27,7 +27,7 @@ function addManifest (pwa) {
     start_url: routerBase + '?standalone=true',
     display: 'standalone',
     background_color: '#ffffff',
-    theme_color: this.options.loading && this.options.loading.color,
+    theme_color: this.options.pwa.meta.theme_color,
     lang: 'en',
     useWebmanifestExtension: false,
     fileName: 'manifest.[hash].[ext]'
@@ -35,7 +35,7 @@ function addManifest (pwa) {
 
   const options = { ...defaults, ...pwa.manifest }
 
-  // Remve extra fields from manifest
+  // Remove extra fields from manifest
   const manifest = { ...options }
   delete manifest.src
   delete manifest.publicPath

--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -27,7 +27,7 @@ function generateMeta (pwa) {
     favicon: true,
     mobileAppIOS: undefined,
     appleStatusBarStyle: 'default',
-    theme_color: this.options.loading && this.options.loading.color,
+    theme_color: undefined,
     lang: 'en',
     ogType: 'website',
     ogSiteName: true,


### PR DESCRIPTION
Fixes issue #223 

Removes the defaults for the meta `theme-color` and the manifest `theme-color` taken from the nuxt loading bar.

To keep user configuration to a minimum, the manifest theme-color's default is now the meta one, if set.
In most real world scenarios they tend to coincide.

Docs updated to reflect the changes, plus a minor fix to the icon/meta links.
