### PR TITLE
fix(meta): add missing `router.base` prefix to favicon

### DIFF
--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -111,7 +111,7 @@ function generateMeta (pwa) {
   if (options.favicon && !find(this.options.head.link, 'rel', 'shortcut icon') && existsSync(favicon)) {
     console.warn('You are using a low quality icon, use icon png. See https://pwa.nuxtjs.org/icon/')
 
-    this.options.head.link.push({ rel: 'shortcut icon', href: 'favicon.ico' })
+    this.options.head.link.push({ rel: 'shortcut icon', href: '/favicon.ico' })
   }
 
   // Title

--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -111,7 +111,7 @@ function generateMeta (pwa) {
   if (options.favicon && !find(this.options.head.link, 'rel', 'shortcut icon') && existsSync(favicon)) {
     console.warn('You are using a low quality icon, use icon png. See https://pwa.nuxtjs.org/icon/')
 
-    this.options.head.link.push({ rel: 'shortcut icon', href: '/favicon.ico' })
+    this.options.head.link.push({ rel: 'shortcut icon', href: this.options.router.base + 'favicon.ico' })
   }
 
   // Title


### PR DESCRIPTION
The favicon must be accessible from any page and it does not matter how deep the page is. The only possible solution is to use a relative url.