### PR TITLE
docs: add meta and article for appleStatusBarStyle

### DIFF
--- a/docs/content/en/meta.md
+++ b/docs/content/en/meta.md
@@ -45,6 +45,9 @@ Please read this resources before you enable `mobileAppIOS` option:
 
 ### `appleStatusBarStyle`
 - Default: `default`
+- Meta: `apple-mobile-web-app-status-bar-style`
+
+This article will help you decide an appropriate value: https://medium.com/appscope/changing-the-ios-status-bar-of-your-progressive-web-app-9fc8fbe8e6ab.
 
 ### `favicon`
 - Default: `true` (to use options.icons)


### PR DESCRIPTION
I added the meta property and helpful article for `appleStatusBarStyle`. I realized that in the [docs](https://pwa.nuxtjs.org/meta#applestatusbarstyle), there's no explanation on what values we should put here. 

The values for meta `apple-mobile-web-app-status-bar-style` are
- `default`
- `black`
- `black-translucent`

Perhaps these values and a one-line explanation could also be added to the Nuxt PWA docs? 

The article linked is [Changing The iOS Status Bar Of Your Progressive Web App](https://medium.com/appscope/changing-the-ios-status-bar-of-your-progressive-web-app-9fc8fbe8e6ab) by Appscope.