### PR TITLE
docs: explain `appleStatusBarStyle` values

### DIFF
--- a/docs/content/en/meta.md
+++ b/docs/content/en/meta.md
@@ -46,6 +46,7 @@ Please read this resources before you enable `mobileAppIOS` option:
 ### `appleStatusBarStyle`
 - Default: `default`
 - Meta: `apple-mobile-web-app-status-bar-style`
+- Requires `mobileAppIOS` to be `true`
 
 There are three options for the status bar style:
 1. `default`: The default status bar style for Safari PWAs; white background with black text and icons.

--- a/docs/content/en/meta.md
+++ b/docs/content/en/meta.md
@@ -47,7 +47,16 @@ Please read this resources before you enable `mobileAppIOS` option:
 - Default: `default`
 - Meta: `apple-mobile-web-app-status-bar-style`
 
-This article will help you decide an appropriate value: https://medium.com/appscope/changing-the-ios-status-bar-of-your-progressive-web-app-9fc8fbe8e6ab.
+There are three options for the status bar style:
+1. `default`: The default status bar style for Safari PWAs; white background with black text and icons.
+2. `black`: Black background with white text and icons.
+3. `black-translucent`: Transparent background with white text and icons. It is [not possible](https://stackoverflow.com/a/40786240/8677167) to have a transparent status bar with black text and icons.
+
+Note that with `black-translucent`, the web content is displayed on the entire screen, partially obscured by the status bar.
+
+These articles will help you decide an appropriate value:
+- https://medium.com/appscope/changing-the-ios-status-bar-of-your-progressive-web-app-9fc8fbe8e6ab.
+- https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW4
 
 ### `favicon`
 - Default: `true` (to use options.icons)


### PR DESCRIPTION
Added an inline summary of the values for appleStatusBarStyle (https://github.com/nuxt-community/pwa-module/pull/357#issuecomment-701997310).

I also added a link to Apple's official documentation (archive): https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW4

In the next commit, I made it clear that `mobileAppIOS` is required 