### PR TITLE
fix(meta): prevent build failure for ios splash image when no icon is used

### DIFF
--- a/lib/icon/module.js
+++ b/lib/icon/module.js
@@ -63,6 +63,8 @@ async function run (pwa, _emitAssets) {
 
   // Disable module if no icon specified
   if (!options.source) {
+    // eslint-disable-next-line no-console
+    console.warn('[pwa] [icon] Icon not found in ' + path.resolve(this.options.srcDir, this.options.dir.static, options.fileName))
     return
   }
 

--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -93,7 +93,7 @@ function generateMeta (pwa) {
     }
 
     // Launch Screen Image (IOS)
-    if (options.mobileAppIOS && !find(this.options.head.link, 'rel', 'apple-touch-startup-image')) {
+    if (options.mobileAppIOS && pwa._iosSplash && !find(this.options.head.link, 'rel', 'apple-touch-startup-image')) {
       this.options.head.link.push({ href: pwa._iosSplash.iphonese, media: '(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)', rel: 'apple-touch-startup-image' })
       this.options.head.link.push({ href: pwa._iosSplash.iphone6, media: '(device-width: 375px) and (device-height: 667px) and (-webkit-device-pixel-ratio: 2)', rel: 'apple-touch-startup-image' })
       this.options.head.link.push({ href: pwa._iosSplash.iphoneplus, media: '(device-width: 621px) and (device-height: 1104px) and (-webkit-device-pixel-ratio: 3)', rel: 'apple-touch-startup-image' })


### PR DESCRIPTION
When the icon is set to false in config, or when the icon is not found correctly, pwa._iosSplash is undefined.
This prevents access to its proprieties and thus the nuxt build failure.

I added also a console.warn that might help in debugging future issues, to try to make it obvious that no icons are actually being generated since the path to the base icon is wrong.

Fixes #355 and #334

