### PR TITLE
[#356] Allow passing an array of ogImages

### DIFF
--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -202,36 +202,40 @@ module.exports = function nuxtMeta (nuxt, pwa, moduleContainer) {
     options.ogImage = { path: options.ogImage }
   }
   if (options.ogImage) {
-    if (options.ogHost || isUrl(options.ogImage.path)) {
-      head.meta.push({
-        hid: 'og:image',
-        name: 'og:image',
-        property: 'og:image',
-        content: isUrl(options.ogImage.path) ? options.ogImage.path : options.ogHost + options.ogImage.path
-      })
-      if (options.ogImage.width && options.ogImage.height) {
+    options.ogImage = Array.isArray(options.ogImage) ? options.ogImage : [options.ogImage]
+    options.ogImage.forEach((ogImage, i) => {
+      const additionalId = i > 0 ? ':' + i : ''
+      if (options.ogHost || isUrl(ogImage.path)) {
         head.meta.push({
-          hid: 'og:image:width',
-          name: 'og:image:width',
-          property: 'og:image:width',
-          content: options.ogImage.width
+          hid: 'og:image' + additionalId,
+          name: 'og:image',
+          property: 'og:image',
+          content: isUrl(ogImage.path) ? ogImage.path : options.ogHost + ogImage.path
         })
-        head.meta.push({
-          hid: 'og:image:height',
-          name: 'og:image:height',
-          property: 'og:image:height',
-          content: options.ogImage.height
-        })
+        if (ogImage.width && ogImage.height) {
+          head.meta.push({
+            hid: 'og:image:width' + additionalId,
+            name: 'og:image:width',
+            property: 'og:image:width',
+            content: ogImage.width
+          })
+          head.meta.push({
+            hid: 'og:image:height' + additionalId,
+            name: 'og:image:height',
+            property: 'og:image:height',
+            content: ogImage.height
+          })
+        }
+        if (ogImage.type) {
+          head.meta.push({
+            hid: 'og:image:type' + additionalId,
+            name: 'og:image:type',
+            property: 'og:image:type',
+            content: ogImage.type
+          })
+        }
       }
-      if (options.ogImage.type) {
-        head.meta.push({
-          hid: 'og:image:type',
-          name: 'og:image:type',
-          property: 'og:image:type',
-          content: options.ogImage.type
-        })
-      }
-    }
+    })
   }
 
   // twitter:card

--- a/types/meta.d.ts
+++ b/types/meta.d.ts
@@ -103,7 +103,7 @@ export interface MetaOptions {
    *
    * Meta: `og:image` and sub-tags
    */
-  ogImage: boolean | string | OgImageObject,
+  ogImage: boolean | string | OgImageObject | OgImageObject[],
   /**
    * Default: ogHost (if defined)
    *


### PR DESCRIPTION
I have dafted an idea, but I'm not sure why the additonal images are not added to the head. 
Every element except the first has an unique hid added (hid + index position).

`  {
    hid: 'og:image',
    name: 'og:image',
    property: 'og:image',
    content: 'https://example.org/image-standard.png'
  },
  {
    hid: 'og:image:width',
    name: 'og:image:width',
    property: 'og:image:width',
    content: 1200
  },
  {
    hid: 'og:image:height',
    name: 'og:image:height',
    property: 'og:image:height',
    content: 630
  },
  {
    hid: 'og:image:type',
    name: 'og:image:type',
    property: 'og:image:type',
    content: 'image/png'
  },
  {
    hid: 'og:image:1',
    name: 'og:image',
    property: 'og:image',
    content: 'https://example.org/image-square.png'
  },
  {
    hid: 'og:image:width:1',
    name: 'og:image:width',
    property: 'og:image:width',
    content: 400
  },
  {
    hid: 'og:image:height:1',
    name: 'og:image:height',
    property: 'og:image:height',
    content: 400
  },
  {
    hid: 'og:image:type:1',
    name: 'og:image:type',
    property: 'og:image:type',
    content: 'image/png'
  }`

=> They are added correctly to the meta array 

Any ideas?