### PR TITLE
feat(meta): preload manifest

### DIFF
--- a/lib/meta/module.js
+++ b/lib/meta/module.js
@@ -252,6 +252,7 @@ module.exports = function nuxtMeta (nuxt, pwa, moduleContainer) {
   // manifest meta
   if (pwa._manifestMeta) {
     head.link.push(pwa._manifestMeta)
+    head.link.push({ rel: 'preload', href: pwa._manifestMeta.href, as: 'fetch' })
   }
 
   moduleContainer.addPlugin({


### PR DESCRIPTION
(fixes #382) Currently, lighthouse suggests preloading manifest:

![image](https://user-images.githubusercontent.com/5158436/96505064-e6e1a600-1255-11eb-9217-e37e2afc2c49.png)


Following up [twitter thread](https://twitter.com/vadim_budarin/status/1004337034536931334) using `as="fetch"` suggested method by @addyosmani:

```html
<link data-n-head="ssr" rel="preload" href="..." as="fetch">
```

This currently leads to this browser warning: (`chrome@86.0.4240.80`)

> The resource http://localhost:4000/_nuxt/manifest_test.webmanifest?d860351d was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.

It seems there is currently an active discussion about related issue regarding `rel="document` ([chromium/593267#c39](https://bugs.chromium.org/p/chromium/issues/detail?id=593267#c39))