### PR TITLE
fix(workbox): add additional details for uncaught errors and fix chromium CORS

### DIFF
--- a/templates/workbox/sw.js
+++ b/templates/workbox/sw.js
@@ -52,12 +52,34 @@ function precacheAssets(workbox, options) {
 
 
 function runtimeCaching(workbox, options) {
+  const requestInterceptor = {
+    requestWillFetch({ request }) {
+      if (request.cache === 'only-if-cached' && request.mode === 'no-cors') {
+        request = new Request(request.url, { ...request, mode: 'no-cors' })
+      }
+      return request
+    },
+    fetchDidFail(ctx) {
+      ctx.error.message =
+        `[workbox] Network request for '${ctx.request.url}' threw an error: ` + ctx.error.message
+      console.error(ctx.error, 'Details:', ctx)
+    },
+    handlerDidError(ctx) {
+      ctx.error.message =
+        `[workbox] Network handler threw an error: ` + ctx.error.message
+      console.error(ctx.error, 'Details:', ctx)
+      return null
+    }
+  }
+
   for (const entry of options.runtimeCaching) {
     const urlPattern = new RegExp(entry.urlPattern)
     const method = entry.method || 'GET'
 
     const plugins = (entry.strategyPlugins || [])
       .map(p => new (getProp(workbox, p.use))(...p.config))
+
+    plugins.unshift(requestInterceptor)
 
     const strategyOptions = { ...entry.strategyOptions, plugins }
 


### PR DESCRIPTION
When opening chromium devtools on first load, it makes a request that violates Request.cache spec: ([chromium#823392](https://bugs.chromium.org/p/chromium/issues/detail?id=823392))

> The "only-if-cached" mode can only be used if the request's mode is "same-origin". Cached redirects will be followed if the request's redirect property is "follow" and the redirects do not violate the "same-origin" mode. ([mdn](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache))

Solution is to rewrite workbox request by detecting this condition and change cache option to `default` 

---

Since there might be more causes for uncaught errors (https://github.com/nuxt-community/pwa-module/issues/176#issuecomment-665722983) this PR is also adding more context to production errors with full context:

Before: (production - debug disabled):

![image](https://user-images.githubusercontent.com/5158436/102716684-b5309e00-42dd-11eb-8eb3-832134d50af6.png)

After: (production)

![image](https://user-images.githubusercontent.com/5158436/102716696-c679aa80-42dd-11eb-86d4-ae8a793493f6.png)

For more context, one may still enable production debugging in `nuxt.config`:

```js
{
  pwa: {
     workbox: { debug: true }
  }
}
```

This PR resolves #176 with best efforts. **IMPORTANT:** Disabling `clientsClaim` as workaround with other defaults is **NOT SAFE** and may cause caching problems and if you was doing it before, should keep it with default value