### PR TITLE
fix(meta): add missing `hid` to icon tags

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -89,8 +89,8 @@ export function meta (nuxt, pwa: PWAContext, moduleContainer) {
 
     // Shortcut icon
     if (options.favicon) {
-      head.link.push({ rel: 'shortcut icon', href: iconSmall.src })
-      head.link.push({ rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes })
+      head.link.push({ hid: 'shortcut-icon', rel: 'shortcut icon', href: iconSmall.src })
+      head.link.push({ hid: `apple-touch-icon`, rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes })
     }
 
     // Launch Screen Image (IOS)
@@ -122,7 +122,7 @@ export function meta (nuxt, pwa: PWAContext, moduleContainer) {
     // TODO: Drop support as it is harmful: https://mathiasbynens.be/notes/rel-shortcut-icon
     const favicon = join(nuxt.options.srcDir, nuxt.options.dir.static, 'favicon.ico')
     if (existsSync(favicon)) {
-      head.link.push({ rel: 'shortcut icon', href: nuxt.options.router.base + 'favicon.ico' })
+      head.link.push({ hid: 'shortcut-icon', rel: 'shortcut icon', href: nuxt.options.router.base + 'favicon.ico' })
     }
   }
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -90,7 +90,7 @@ export function meta (nuxt, pwa: PWAContext, moduleContainer) {
     // Shortcut icon
     if (options.favicon) {
       head.link.push({ hid: 'shortcut-icon', rel: 'shortcut icon', href: iconSmall.src })
-      head.link.push({ hid: `apple-touch-icon`, rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes })
+      head.link.push({ hid: 'apple-touch-icon', rel: 'apple-touch-icon', href: iconBig.src, sizes: iconBig.sizes })
     }
 
     // Launch Screen Image (IOS)


### PR DESCRIPTION
The favicon head links were pushed without `hid` and `name` and they weren't deduplicated in `mergeMeta`: https://github.com/nuxt-community/pwa-module/blob/245aadc3c3111c1eff0bf18ff775bb248a708867/lib/meta.utils.js#L13-L19
As a result they were appended every time the page was visited, causing a memory leak and crashing the server after some time.