### PR TITLE
fix: support regex using `devalue`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "yarn lint && jest"
   },
   "dependencies": {
+    "@nuxt/devalue": "^1.2.5",
     "clone-deep": "^4.0.1",
     "defu": "^3.2.2",
     "execa": "^5.0.0",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import devalue from '@nuxt/devalue'
 import { posix, resolve, dirname } from 'path'
 import { mkdirp, readFile, existsSync, writeFile } from 'fs-extra'
 import template from 'lodash.template'
@@ -102,7 +103,10 @@ export function pick (obj, props) {
 }
 
 export async function copyTemplate ({ src, dst, options }) {
-  const compile = template(await readFile(src, 'utf8'))
+  const compile = template(
+    await readFile(src, 'utf8'),
+    { imports: { devalue } }
+  )
   await writeFile(dst, compile({ options }))
 }
 

--- a/templates/workbox/sw.js
+++ b/templates/workbox/sw.js
@@ -1,4 +1,4 @@
-const options = <%= JSON.stringify(options.swOptions) %>
+const options = <%= devalue(options.swOptions) %>
 
 importScripts(...[options.workboxURL, ...options.importScripts])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,13 @@
   dependencies:
     consola "^2.9.0"
 
+"@nuxt/devalue@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@nuxt/devalue/-/devalue-1.2.5.tgz#8d95e3e74b3332d3eb713342c5c4d18096047d66"
+  integrity sha512-Tg86C7tqzvZtZli2BQVqgzZN136mZDTgauvJXagglKkP2xt5Kw3NUIiJyjX0Ww/IZy2xVmD0LN+CEPpij4dB2g==
+  dependencies:
+    consola "^2.9.0"
+
 "@nuxt/friendly-errors-webpack-plugin@^2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@nuxt/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-2.5.0.tgz#5374665bc72d34b7dbadcc361a4777e3f0f5d46b"


### PR DESCRIPTION
Module uses `JSON.stringify` to encode workbox options. This PR add `@nuxt/devalue` as direct dependency and uses it to encode options.

resolves #281 