### PR TITLE
fix: Use manifest 'name' for 'short_name' if provided

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -8,7 +8,7 @@ export function manifest (nuxt, pwa: PWAContext) {
   // Combine sources
   const defaults: ManifestOptions = {
     name: process.env.npm_package_name,
-    short_name: process.env.npm_package_name,
+    short_name: pwa.manifest.name || process.env.npm_package_name,
     description: process.env.npm_package_description,
     publicPath,
     icons: [],


### PR DESCRIPTION
The current default manifest `short_name` is the project package name, even when a custom name is provided for the manifest. This is not ideal as developers might assume that when `name` is provided, `short_name` would default to be the same as `name`, especially that it's optional (https://developer.mozilla.org/en-US/docs/Web/Manifest/short_name).

This patch uses the `name` value (if provided) for `short_name`, and otherwise uses the project package name as usual.